### PR TITLE
Preserve hidden properties

### DIFF
--- a/src/View/Schema/EntitySchema.php
+++ b/src/View/Schema/EntitySchema.php
@@ -70,7 +70,8 @@ class EntitySchema extends SchemaProvider
     public function getAttributes($resource)
     {
         if ($resource->has($this->idField)) {
-            $resource->hiddenProperties([$this->idField]);
+            $hidden = array_merge($resource->hiddenProperties(), [$this->idField]);
+            $resource->hiddenProperties($hidden);
         }
 
         return $resource->toArray();

--- a/src/View/Schema/EntitySchema.php
+++ b/src/View/Schema/EntitySchema.php
@@ -60,7 +60,7 @@ class EntitySchema extends SchemaProvider
      * Get resource id.
      *
      * @param \Cake\ORM\Entity $resource
-     * @return array
+     * @return mixed
      */
     public function getId($resource)
     {

--- a/src/View/Schema/EntitySchema.php
+++ b/src/View/Schema/EntitySchema.php
@@ -57,7 +57,10 @@ class EntitySchema extends SchemaProvider
     }
 
     /**
-     * {@inheritDoc}
+     * Get resource id.
+     *
+     * @param \Cake\ORM\Entity $resource
+     * @return array
      */
     public function getId($resource)
     {
@@ -65,7 +68,10 @@ class EntitySchema extends SchemaProvider
     }
 
     /**
-     * {@inheritDoc}
+     * Get resource attributes.
+     *
+     * @param \Cake\ORM\Entity $resource
+     * @return array
      */
     public function getAttributes($resource)
     {

--- a/src/View/Schema/EntitySchema.php
+++ b/src/View/Schema/EntitySchema.php
@@ -60,11 +60,11 @@ class EntitySchema extends SchemaProvider
      * Get resource id.
      *
      * @param \Cake\ORM\Entity $resource Entity resource
-     * @return mixed
+     * @return string
      */
     public function getId($resource)
     {
-        return $resource->get($this->idField);
+        return (string)$resource->get($this->idField);
     }
 
     /**

--- a/src/View/Schema/EntitySchema.php
+++ b/src/View/Schema/EntitySchema.php
@@ -59,7 +59,7 @@ class EntitySchema extends SchemaProvider
     /**
      * Get resource id.
      *
-     * @param \Cake\ORM\Entity $resource
+     * @param \Cake\ORM\Entity $resource Entity resource
      * @return mixed
      */
     public function getId($resource)
@@ -70,7 +70,7 @@ class EntitySchema extends SchemaProvider
     /**
      * Get resource attributes.
      *
-     * @param \Cake\ORM\Entity $resource
+     * @param \Cake\ORM\Entity $resource Entity resource
      * @return array
      */
     public function getAttributes($resource)


### PR DESCRIPTION
Setting new hiddenProperties overrides the original defined in the Entity. Merging the original with the new fix the problem.

Also add PHPDoc blocks to EntitySchema methods.
