### PR TITLE
Treat '_serialize' the same way as JsonView.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ public function initialize()
 
 public function index()
 {
-	$clients = $this->Articles->find()
+	$articles = $this->Articles->find()
 		->all();
 
-	$this->set('_serialize', $clients);
+	$this->set(compact('articles'));
+	$this->set('_serialize', true);
 
 	// optional parameters
 	$this->set('_include', [ 'articles', 'articles.comments' ]);


### PR DESCRIPTION
In CakePHP 3.1, the way JsonView use the `_serialize` key changed (see [more here](http://book.cakephp.org/3.0/en/appendices/3-1-migration-guide.html#view)).

This pull updates JsonApiView to follow the JsonView convetion and allow the controllers to switch between content types easily.

Note that now if an object is assigned to _serialize, JsonApiView trigger an E_USER_DEPRECATED error.

Refs #3.
