### PR TITLE
Add aliased entityschema

### DIFF
--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -131,6 +131,10 @@ class JsonApiView extends View
         $parameters = $serialize = $url = null;
         $jsonOptions = $this->_jsonOptions();
 
+        if (isset($this->viewVars['_serialize']) && $this->viewVars['_serialize'] !== false) {
+            $serialize = $this->_dataToSerialize($this->viewVars['_serialize']);
+        }
+
         if (isset($this->viewVars['_url'])) {
             $url = rtrim($this->viewVars['_url'], '/');
         }
@@ -149,16 +153,12 @@ class JsonApiView extends View
             $fieldsets = $this->viewVars['_fieldsets'];
         }
 
-        if (isset($this->viewVars['_links'])) {
-            $links = $this->viewVars['_links'];
-        }
-
         if (isset($this->viewVars['_meta'])) {
             $meta = $this->viewVars['_meta'];
         }
 
-        if (isset($this->viewVars['_serialize']) && $this->viewVars['_serialize'] !== false) {
-            $serialize = $this->_dataToSerialize($this->viewVars['_serialize']);
+        if (isset($this->viewVars['_links'])) {
+            $links = $this->viewVars['_links'];
         }
 
         $encoderOptions = new EncoderOptions($jsonOptions, $url);

--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -80,14 +80,18 @@ class JsonApiView extends View
                 throw new MissingEntityException([$entityName]);
             }
 
-            $schemaClass = App::className($entityName, 'View\Schema', 'Schema');
+            $schemaClass = App::className($aliasedEntityName, 'View\Schema', 'Schema');
+
+            if (!$schemaClass) {
+                $schemaClass = App::className($entityName, 'View\Schema', 'Schema');
+            }
 
             if (!$schemaClass) {
                 $schemaClass = App::className('JsonApi.Entity', 'View\Schema', 'Schema');
             }
 
-            $schema = function ($factory, $container) use ($schemaClass, $aliasedEntityName) {
-                return new $schemaClass($factory, $container, $this, $aliasedEntityName);
+            $schema = function ($factory, $container) use ($schemaClass, $entityName) {
+                return new $schemaClass($factory, $container, $this, $entityName);
             };
 
             $schemas[$entityClass] = $schema;

--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -72,10 +72,11 @@ class JsonApiView extends View
 
         $schemas = [];
         $entities = Hash::normalize($entities);
-        foreach ($entities as $entityName => $options) {
-            $entityclass = App::className($entityName, 'Model\Entity');
+        foreach ($entities as $aliasedEntityName => $entityName) {
+            $entityName = $entityName ? : $aliasedEntityName;
+            $entityClass = App::className($entityName, 'Model\Entity');
 
-            if (!$entityclass) {
+            if (!$entityClass) {
                 throw new MissingEntityException([$entityName]);
             }
 
@@ -85,11 +86,11 @@ class JsonApiView extends View
                 $schemaClass = App::className('JsonApi.Entity', 'View\Schema', 'Schema');
             }
 
-            $schema = function ($factory, $container) use ($schemaClass, $entityName) {
-                return new $schemaClass($factory, $container, $this, $entityName);
+            $schema = function ($factory, $container) use ($schemaClass, $aliasedEntityName) {
+                return new $schemaClass($factory, $container, $this, $aliasedEntityName);
             };
 
-            $schemas[$entityclass] = $schema;
+            $schemas[$entityClass] = $schema;
         }
 
         return $schemas;

--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -157,9 +157,6 @@ class JsonApiView extends View
             $meta = $this->viewVars['_meta'];
         }
 
-//        if (isset($this->viewVars['_serialize'])) {
-//            $serialize = $this->viewVars['_serialize'];
-//        }
         if (isset($this->viewVars['_serialize']) && $this->viewVars['_serialize'] !== false) {
             $serialize = $this->_dataToSerialize($this->viewVars['_serialize']);
         }

--- a/tests/Fixture/authors.json
+++ b/tests/Fixture/authors.json
@@ -4,9 +4,7 @@
             "type": "authors",
             "id": "1",
             "attributes": {
-                "title": null,
-                "body": null,
-                "published": null
+                "name": "mariano"
             },
             "relationships": {
                 "articles": {
@@ -30,9 +28,7 @@
             "type": "authors",
             "id": "2",
             "attributes": {
-                "title": null,
-                "body": null,
-                "published": null
+                "name": "nate"
             },
             "relationships": {
                 "articles": {
@@ -47,9 +43,7 @@
             "type": "authors",
             "id": "3",
             "attributes": {
-                "title": null,
-                "body": null,
-                "published": null
+                "name": "larry"
             },
             "relationships": {
                 "articles": {
@@ -69,9 +63,7 @@
             "type": "authors",
             "id": "4",
             "attributes": {
-                "title": null,
-                "body": null,
-                "published": null
+                "name": "garrett"
             },
             "relationships": {
                 "articles": {

--- a/tests/TestCase/View/JsonApiViewTest.php
+++ b/tests/TestCase/View/JsonApiViewTest.php
@@ -104,7 +104,7 @@ class JsonApiViewTest extends TestCase
             '_url' => 'http://localhost',
             '_entities' => [
                 'Publisher' => 'Author',
-                'PublishedArticle' => 'Article'
+                'Article'
             ],
             '_include' => ['articles']
         ]);
@@ -112,7 +112,7 @@ class JsonApiViewTest extends TestCase
         $expected = '{
     "data": [
         {
-            "type": "publishers",
+            "type": "authors",
             "id": "1",
             "attributes": {
                 "name": "mariano"
@@ -121,11 +121,11 @@ class JsonApiViewTest extends TestCase
                 "articles": {
                     "data": [
                         {
-                            "type": "publishedarticles",
+                            "type": "articles",
                             "id": "1"
                         },
                         {
-                            "type": "publishedarticles",
+                            "type": "articles",
                             "id": "3"
                         }
                     ]
@@ -138,7 +138,7 @@ class JsonApiViewTest extends TestCase
     ],
     "included": [
         {
-            "type": "publishedarticles",
+            "type": "articles",
             "id": "1",
             "attributes": {
                 "author_id": 1,
@@ -148,7 +148,7 @@ class JsonApiViewTest extends TestCase
             }
         },
         {
-            "type": "publishedarticles",
+            "type": "articles",
             "id": "3",
             "attributes": {
                 "author_id": 1,

--- a/tests/TestCase/View/JsonApiViewTest.php
+++ b/tests/TestCase/View/JsonApiViewTest.php
@@ -86,6 +86,82 @@ class JsonApiViewTest extends TestCase
         );
     }
 
+    /**
+     * Test Render
+     * @return [type] [description]
+     */
+    public function testRenderUsingAliasedEntitySchema()
+    {
+        $records = TableRegistry::get('Authors')->find()
+            ->contain(['Articles'])
+            ->where(['Authors.id' => 1])
+            ->all();
+
+
+        $view = $this->_getView([
+            'author' => $records,
+            '_serialize' => true,
+            '_url' => 'http://localhost',
+            '_entities' => [
+                'Publisher' => 'Author',
+                'PublishedArticle' => 'Article'
+            ],
+            '_include' => ['articles']
+        ]);
+
+        $expected = '{
+    "data": [
+        {
+            "type": "publishers",
+            "id": "1",
+            "attributes": {
+                "name": "mariano"
+            },
+            "relationships": {
+                "articles": {
+                    "data": [
+                        {
+                            "type": "publishedarticles",
+                            "id": "1"
+                        },
+                        {
+                            "type": "publishedarticles",
+                            "id": "3"
+                        }
+                    ]
+                }
+            },
+            "links": {
+                "self": "http:\/\/localhost\/publishers\/1"
+            }
+        }
+    ],
+    "included": [
+        {
+            "type": "publishedarticles",
+            "id": "1",
+            "attributes": {
+                "author_id": 1,
+                "title": "First Article",
+                "body": "First Article Body",
+                "published": "Y"
+            }
+        },
+        {
+            "type": "publishedarticles",
+            "id": "3",
+            "attributes": {
+                "author_id": 1,
+                "title": "Third Article",
+                "body": "Third Article Body",
+                "published": "Y"
+            }
+        }
+    ]
+}';
+        $this->assertJsonStringEqualsJsonString($expected, $view->render());
+    }
+
     public function testViewResponse()
     {
         $records = TableRegistry::get('Articles')->find()->all();

--- a/tests/test_app/TestApp/View/Schema/AuthorSchema.php
+++ b/tests/test_app/TestApp/View/Schema/AuthorSchema.php
@@ -13,9 +13,7 @@ class AuthorSchema extends EntitySchema
     public function getAttributes($entity)
     {
         return [
-            'title' => $entity->title,
-            'body' => $entity->body,
-            'published' => $entity->published
+            'name' => $entity->name,
         ];
     }
 

--- a/tests/test_app/TestApp/View/Schema/PublisherSchema.php
+++ b/tests/test_app/TestApp/View/Schema/PublisherSchema.php
@@ -1,0 +1,10 @@
+<?php
+namespace TestApp\View\Schema;
+
+class PublisherSchema extends AuthorSchema
+{
+    /**
+     * @var string Must end with '/'
+     */
+    protected $selfSubUrl = '/publishers/';
+}


### PR DESCRIPTION
The 3 firsts commits are just fixes. The last commit is the one that introduces the change. As the commit message states:

Allow to render the entity with an alias.
Just like it's possible to set an alias to a table's association, JsonApi needs to allow set alias for existing entities.

For example, to set a custom resource object type, the user can assign to the `_include` key an associative array with:

```
'_include' => [
    'Publisher' => 'Author'
]
```

Then the JsonApi will use the AuthorSchema to render the object, but the object type will be 'publishers'.

The changes are tested and doesn't break the compatibility with the current code.
