### PR TITLE
Enable phpunit for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ php:
 sudo: false
 
 env:
-  - DB=sqlite
-
   global:
     - DEFAULT=1
+    - DB=sqlite
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ sudo: false
 env:
   - DB=sqlite
 
+  global:
+    - DEFAULT=1
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Looks like PHPUNIT is never executed by travis due to missing global. This should solve that.
